### PR TITLE
Sanitize replication agent namens because dots are not allowed

### DIFF
--- a/tasks/flush-test.yml
+++ b/tasks/flush-test.yml
@@ -1,6 +1,6 @@
-- name: "Running connection test for '{{ flush_target.name }}', type: '{{ type }}'"
+- name: "Running connection test for '{{ flush_target.name | regex_replace('\\.', '_') }}', type: '{{ type }}'"
   uri:
-    url: "http://localhost:{{ port }}/etc/replication/agents.{{ type }}/flush_{{ flush_target.name }}.test.html"
+    url: "http://localhost:{{ port }}/etc/replication/agents.{{ type }}/flush_{{ flush_target.name | regex_replace('\\.', '_') }}.test.html"
     user: "{{ conga_aemst_user }}"
     password: "{{ conga_aemst_password }}"
     force_basic_auth: yes

--- a/tasks/publish-test.yml
+++ b/tasks/publish-test.yml
@@ -1,6 +1,6 @@
-- name: Running connection test for '{{ publish_target.name }}'
+- name: "Running connection test for '{{ publish_target.name | regex_replace('\\.', '_') }}'"
   uri:
-    url: "http://localhost:{{ port }}/etc/replication/agents.author/publish_{{ publish_target.name }}.test.html"
+    url: "http://localhost:{{ port }}/etc/replication/agents.author/publish_{{ publish_target.name | regex_replace('\\.', '_') }}.test.html"
     user: "{{ conga_aemst_user }}"
     password: "{{ conga_aemst_password }}"
     return_content: yes


### PR DESCRIPTION
With https://github.com/wcm-io-devops/conga-aem-definitions/pull/36 the replication agent names are getting sanitized since dots are not allowed in agent namens.

This PR adjusts the naming behavior by replacing dots in the agent names retrieved from conga_facts.