### PR TITLE
Increase timeouts to 60 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,17 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The text to search for on the publish test result page.
 
+    conga_aemst_publish_test_timeout: 60
+
+The timeout for the publish test.
+
     conga_aemst_flush_test_pattern: "succeeded"
 
 The text to search for on the flush test result page.
+
+    conga_aemst_flush_test_timeout: 60
+
+The timeout for the flush test.
 
     conga_aemst_user: "{{ conga_config.quickstart.adminUser.username | default('admin')}}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,14 @@
 # The text to search for on the publish test result page
 conga_aemst_publish_test_pattern: "succeeded"
 
+# The timeout for the publish test
+conga_aemst_publish_test_timeout: 60
+
 # The text to search for on the flush test result page
 conga_aemst_flush_test_pattern: "succeeded"
+
+# The timeout for the flush test
+conga_aemst_flush_test_timeout: 60
 
 # The username to use.
 conga_aemst_user: "{{ conga_config.quickstart.adminUser.username | default('admin')}}"

--- a/tasks/flush-test.yml
+++ b/tasks/flush-test.yml
@@ -9,5 +9,6 @@
     password: "{{ conga_aemst_password }}"
     force_basic_auth: yes
     return_content: yes
+    timeout: "{{ conga_aemst_flush_test_timeout }}"
   register: flush_test_result
   failed_when: conga_aemst_flush_test_pattern not in flush_test_result.content

--- a/tasks/publish-test.yml
+++ b/tasks/publish-test.yml
@@ -8,5 +8,6 @@
     user: "{{ conga_aemst_user }}"
     password: "{{ conga_aemst_password }}"
     return_content: yes
+    timeout: "{{ conga_aemst_publish_test_timeout }}"
   register: connection_test_result
   failed_when: conga_aemst_publish_test_pattern not in connection_test_result.content


### PR DESCRIPTION
Sometimes the smoketests failed because the used uri module got an timeout. This PR introduced configuration variables and sets the default value to 60 seconds.