### PR TITLE
Don't prefix publish test URL with "publish_"

### DIFF
--- a/tasks/publish-test.yml
+++ b/tasks/publish-test.yml
@@ -5,7 +5,7 @@
 
 - name: "Running connection test for '{{ __publish_agent_name }}'."
   uri:
-    url: "http://localhost:{{ port }}/etc/replication/agents.author/publish_{{ __publish_agent_name }}.test.html"
+    url: "http://localhost:{{ port }}/etc/replication/agents.author/{{ __publish_agent_name }}.test.html"
     user: "{{ conga_aemst_user }}"
     password: "{{ conga_aemst_password }}"
     return_content: yes


### PR DESCRIPTION
In the latest CONGA AEM Definitions release, the naming of the publish agent was altered (see https://github.com/wcm-io-devops/conga-aem-definitions/blob/develop/changes.xml#L39-L41). This change fixes the smoke test for builds that use this new release.